### PR TITLE
Rename the gem to `Repositorish`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,4 +4,4 @@ Metrics/LineLength:
 Style/Documentation:
   Exclude:
     - spec/**/*
-    - lib/warehouse/version.rb
+    - lib/repositorish/version.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ deploy:
   provider: rubygems
   api_key:
     secure: WutIgn21Jgy0Q3E/y47pALrxmyEEPMNWg7a0WEcGL72EfEhge0BG9FtiSds5uXbeA77PPQ4bNtZlkfv2wvm6ceJmQLO8HMnhqptZLAPTUqnyhlX9g2Cn0qHpm2heujlT2ORoE1+x4GB1f03OH3WaBliDat5hbd/CS0CJsZI9AJOo0TnbCJZ66E+TMfQAr+tDMDaBfNnWQAg0cXd3g2qfa1tmHnVhbpRahqgBxaC7XKYyHT7Y2TwSYePjc7yK/e9HxRF3zdBEGiq8tGFzvVSsT1NjujdJGyXRKRmDrl/yCHx5NwTXLVBuu/eitIP0zuVSIUrnSptU+Yo654DpVILzlLhdnuL5vhrl280YE3lrknYVh9udp2H9W7GKnCqRKEesUhNGHUHXsp1eBm+4h05B0ZiqYSKbNokeCwvG0aZpM13qa7mE1nnPa+gHznxk/Z0y5lzm9b/NNB2kzsp5tHTAi+ANedZ7K0nqk1gI3IMonUtujq8xe2sio0JQ7NGRp6zTL3eF3HJr6yTLxEYHfoXq7TNxPUX8BwskH24TAF0/HtRTSM47z5voBiGOUttFa1rTz+WmUu7V5cpgCFWjEfUiHgwDu35VmHZe8LWXclQFJU6mHm49p25asrnwxqTiFHG0hX31RaxwT4QhKOpB+y5PlELrPeQvpnrIE8z1jegcB98=
-  gem: warehouse
+  gem: repositorish
   on:
     tags: true
-    repo: LoveMondays/warehouse
+    repo: LoveMondays/repositorish
     branch: master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Warehouse
-[![Build Status](https://travis-ci.org/LoveMondays/warehouse.svg)](https://travis-ci.org/LoveMondays/warehouse) [![Code Climate](https://codeclimate.com/github/LoveMondays/warehouse/badges/gpa.svg)](https://codeclimate.com/github/LoveMondays/warehouse) [![Test Coverage](https://codeclimate.com/github/LoveMondays/warehouse/badges/coverage.svg)](https://codeclimate.com/github/LoveMondays/warehouse/coverage)
+# Repositorish
+[![Build Status](https://travis-ci.org/LoveMondays/repositorish.svg)](https://travis-ci.org/LoveMondays/repositorish) [![Code Climate](https://codeclimate.com/github/LoveMondays/repositorish/badges/gpa.svg)](https://codeclimate.com/github/LoveMondays/repositorish) [![Test Coverage](https://codeclimate.com/github/LoveMondays/repositorish/badges/coverage.svg)](https://codeclimate.com/github/LoveMondays/repositorish/coverage)
 
 Simple Repository(ish) solution to hold query and command logic into self contained objects
 
@@ -8,7 +8,7 @@ Simple Repository(ish) solution to hold query and command logic into self contai
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'warehouse'
+gem 'repositorish'
 ```
 
 And then execute:
@@ -17,7 +17,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install warehouse
+    $ gem install repositorish
 
 ## Usage
 
@@ -29,9 +29,9 @@ end
 
 ```ruby
 class UserRepository
-  include Warehouse
+  include Repositorish
 
-  warehouse :user, scope: :all
+  repositorish :user, scope: :all
 
   def confirmed
     where.not(confirmed_at: nil)
@@ -74,7 +74,7 @@ end
   # => [#<User name: 'Mary'>]
 
   UserRepository.alphabetically
-  # => Warehouse::DomainMethodError: Direct call on domain's methods is not allowed
+  # => Repositorish::DomainMethodError: Direct call on domain's methods is not allowed
 
   UserRepository.active.destroy_all
   # => [#<User name: 'Mary'>]
@@ -91,7 +91,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-1. Fork it ( https://github.com/LoveMondays/warehouse/fork )
+1. Fork it ( https://github.com/LoveMondays/repositorish/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/repositorish/version.rb
+++ b/lib/repositorish/version.rb
@@ -1,3 +1,3 @@
-module Warehouse
+module Repositorish
   VERSION = '0.1.0'.freeze
 end

--- a/repositorish.gemspec
+++ b/repositorish.gemspec
@@ -1,17 +1,17 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require 'warehouse/version'
+require 'repositorish/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'warehouse'
-  s.version     = Warehouse::VERSION
+  s.name        = 'repositorish'
+  s.version     = Repositorish::VERSION
   s.platform    = Gem::Platform::RUBY
 
   s.date        = '2015-11-10'
   s.summary     = 'Simple Repository(ish) solution to hold query and ' \
                   'command logic into self contained objects'
-  s.homepage    = 'https://github.com/LoveMondays/warehouse'
+  s.homepage    = 'https://github.com/LoveMondays/repositorish'
   s.license     = 'MIT'
 
   s.authors     = ['Glauber Campinho', 'Brenno Costa']

--- a/spec/integration/active_record_spec.rb
+++ b/spec/integration/active_record_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe 'ActiveRecord integration' do
     end
 
     class UserRepository
-      include Warehouse
+      include Repositorish
 
-      warehouse :user, scope: :all
+      repositorish :user, scope: :all
 
       def confirmed
         where.not(confirmed_at: nil)
@@ -68,6 +68,6 @@ RSpec.describe 'ActiveRecord integration' do
   end
 
   it 'raises domain method error when directly calls domain methods' do
-    expect { UserRepository.alphabetically }.to raise_error(Warehouse::DomainMethodError)
+    expect { UserRepository.alphabetically }.to raise_error(Repositorish::DomainMethodError)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ if ENV['CODECLIMATE_REPO_TOKEN']
 end
 
 require 'rspec'
-require 'warehouse'
+require 'repositorish'
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|

--- a/spec/warehouse_spec.rb
+++ b/spec/warehouse_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'ostruct'
 
-RSpec.describe Warehouse do
+RSpec.describe Repositorish do
   before(:all) do
     class Model
       def new_record?; end
@@ -37,7 +37,7 @@ RSpec.describe Warehouse do
   end
 
   it "delegates calls on class to instance's defined domains" do
-    repository_class.warehouse :model, scope: :all
+    repository_class.repositorish :model, scope: :all
     expect(repository_class.custom_scope).to eq(repository_class.new(Model.all).custom_scope)
   end
 
@@ -46,27 +46,27 @@ RSpec.describe Warehouse do
     expect(Model).to receive(:all) { relation }
     expect(relation).to receive(:where).with(test: true)
 
-    repository_class.warehouse :model, scope: :all
+    repository_class.repositorish :model, scope: :all
     repository = repository_class.query
     repository.where(test: true)
   end
 
-  describe '.warehouse' do
+  describe '.repositorish' do
     subject { repository_class }
 
     it 'defines repository domain with the model passed if no option is passed' do
-      subject.warehouse :model
+      subject.repositorish :model
       expect(subject.instance_variable_get('@domain')).to eq(Model)
     end
 
     it 'defines repository domain with the model passed contextualized in the scope option' do
-      subject.warehouse :model, scope: :all
+      subject.repositorish :model, scope: :all
       expect(subject.instance_variable_get('@domain')).to eq(Model.all)
     end
   end
 
   describe '.create' do
-    subject { repository_class.warehouse(:model, scope: :all) }
+    subject { repository_class.repositorish(:model, scope: :all) }
 
     it 'does not create if the model is already persisted' do
       model = Model.new
@@ -84,7 +84,7 @@ RSpec.describe Warehouse do
   end
 
   describe '.update' do
-    subject { repository_class.warehouse(:model, scope: :all) }
+    subject { repository_class.repositorish(:model, scope: :all) }
 
     it 'does not update if the model is a new record' do
       model = Model.new
@@ -102,7 +102,7 @@ RSpec.describe Warehouse do
   end
 
   describe '.destroy' do
-    subject { repository_class.warehouse(:model, scope: :all) }
+    subject { repository_class.repositorish(:model, scope: :all) }
 
     it 'destroys if the model is already persisted' do
       model = Model.new
@@ -120,17 +120,17 @@ RSpec.describe Warehouse do
   end
 
   describe '.query' do
-    subject { repository_class.warehouse(:model, scope: :all) }
+    subject { repository_class.repositorish(:model, scope: :all) }
 
-    it 'returns a warehouse instance with configured domain' do
+    it 'returns a repositorish instance with configured domain' do
       query = subject.query
-      expect(query).to be_kind_of(Warehouse)
+      expect(query).to be_kind_of(Repositorish)
       expect(query.instance_variable_get('@domain')).to eq(Model.all)
     end
 
-    it 'returns a warehouse instance with custom domain passed as argument' do
+    it 'returns a repositorish instance with custom domain passed as argument' do
       query = subject.query(Model.where(test: true))
-      expect(query).to be_kind_of(Warehouse)
+      expect(query).to be_kind_of(Repositorish)
       expect(query.instance_variable_get('@domain')).to eq(Model.where(test: true))
     end
   end


### PR DESCRIPTION
- Rename the gem to `Repositorish`
- Rename the `ACTIVE_RECORD_NAMESPACE_REGEX` to `CHAINABLE_NAMESPACES_REGEX`, let the porpouse more clear
