### PR TITLE
Disable bundler-audit

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,7 @@
 ---
 engines:
   bundler-audit:
-    enabled: true
+    enabled: false
   fixme:
     enabled: true
   rubocop:


### PR DESCRIPTION
bundler-audit needs a `Gemfile.lock` to work with, which we don't have
