### PR TITLE
Define `respond_to_missing?` for Repositorish

### DIFF
--- a/lib/repositorish.rb
+++ b/lib/repositorish.rb
@@ -21,8 +21,8 @@ require 'repositorish/version'
 # # => <User::ActiveRecord_Relation ...>
 # ```
 module Repositorish
-  CHAINABLE_NAMESPACES = %w(ActiveRecord ActiveRecord_Relation ActiveRecord_AssociationRelation)
-  CHAINABLE_NAMESPACES_REGEX = /(?:^|::)(?:#{CHAINABLE_NAMESPACES.join('|')})(?:$|::)/.freeze
+  CHAINABLE_NAMESPACES = %w(ActiveRecord ActiveRecord_Relation ActiveRecord_AssociationRelation).freeze
+  CHAINABLE_NAMESPACES_REGEX = /(?:^|::)(?:#{CHAINABLE_NAMESPACES.join('|')})(?:$|::)/
 
   def self.included(base)
     base.send :extend, ClassMethods
@@ -97,7 +97,7 @@ module Repositorish
     def method_missing(method, *args, &block)
       return query.public_send(method, *args, &block) if method_defined?(method)
 
-      fail DomainMethodError, method if @domain.respond_to?(method)
+      raise DomainMethodError, method if @domain.respond_to?(method)
       super
     end
   end

--- a/lib/repositorish.rb
+++ b/lib/repositorish.rb
@@ -60,6 +60,10 @@ module Repositorish
     domain.class == @domain.class
   end
 
+  def respond_to_missing?(method_name, include_private = false)
+    domain.respond_to?(method_name) || super
+  end
+
   # :nodoc:
   module ClassMethods
     def repositorish(model, options = {})

--- a/spec/integration/active_record_spec.rb
+++ b/spec/integration/active_record_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'ActiveRecord integration' do
     mary = User.create(name: 'Mary', last_sign_in_at: 1.day.ago, confirmed_at: 2.day.ago)
     john = User.create(name: 'John', last_sign_in_at: 2.week.ago, confirmed_at: 1.month.ago)
 
+    expect(UserRepository.active).to respond_to(:count)
     expect(UserRepository.confirmed).to contain_exactly(john, mary)
     expect(UserRepository.active).to contain_exactly(mary)
   end


### PR DESCRIPTION
Redefining `method_missing` without defining a correspondent
`respond_to_missing?` can drive to misleading behaviours. For example
one can expect their repositorish to respond to some AR extensions'
methods, like `total_count` for Kaminari
